### PR TITLE
fix for rails4 routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
 
-  match 'bootstrap_view_helpers(/:action)' => 'bootstrap_view_helpers', :as => :bvh
+  get 'bootstrap_view_helpers(/:action)' => 'bootstrap_view_helpers', :as => :bvh
   
 end


### PR DESCRIPTION
Rails4 does not accept match on routes anymore. You have to specify the request method or use resource.
